### PR TITLE
feat: add verify order functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@
 # one found in a remote Prisma Postgres URL, does not contain any sensitive information.
 
 DATABASE_URL="postgres://xxx"
+SECONDARY_MARKET_CONTRACT_ADDRESS="0xxxxx"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/src/orders/dto/salted-order.dto.ts
+++ b/src/orders/dto/salted-order.dto.ts
@@ -1,5 +1,0 @@
-import { CreateOrderDto } from './create-order.dto';
-
-export class SaltedOrderDto extends CreateOrderDto {
-  salt: string;
-}

--- a/src/orders/dto/unsigned-typed-data.dto.ts
+++ b/src/orders/dto/unsigned-typed-data.dto.ts
@@ -1,0 +1,25 @@
+import { Address, TypedDataDomain } from 'viem';
+
+export class UnsignedTypedDataDto {
+  account: Address;
+  domain: TypedDataDomain;
+  types: {
+    Order: readonly [
+      { name: 'maker'; type: 'address' },
+      { name: 'makerToken'; type: 'address' },
+      { name: 'makerAmount'; type: 'uint256' },
+      { name: 'takerToken'; type: 'address' },
+      { name: 'takerAmount'; type: 'uint256' },
+      { name: 'salt'; type: 'string' },
+    ];
+  };
+  primaryType: 'Order';
+  message: {
+    maker: string;
+    makerToken: string;
+    makerAmount: string;
+    takerToken: string;
+    takerAmount: string;
+    salt: string;
+  };
+}

--- a/src/orders/dto/update-order.dto.ts
+++ b/src/orders/dto/update-order.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateOrderDto } from './create-order.dto';
-
-export class UpdateOrderDto extends PartialType(CreateOrderDto) {}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,42 +1,24 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-} from '@nestjs/common';
+import { Controller, Post, Body } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
-import { UpdateOrderDto } from './dto/update-order.dto';
+import { UnsignedTypedDataDto } from './dto/unsigned-typed-data.dto';
 
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
-  @Post()
-  async create(@Body() createOrderDto: CreateOrderDto) {
+  @Post('create')
+  async create(
+    @Body() createOrderDto: CreateOrderDto,
+  ): Promise<UnsignedTypedDataDto> {
     return await this.ordersService.create(createOrderDto);
   }
 
-  @Get()
-  findAll() {
-    return this.ordersService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.ordersService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateOrderDto: UpdateOrderDto) {
-    return this.ordersService.update(+id, updateOrderDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.ordersService.remove(+id);
+  @Post('verify')
+  async verifySignedOrder(
+    @Body() order: UnsignedTypedDataDto,
+    @Body() signature: string,
+  ) {
+    return await this.ordersService.verifySignedOrder(order, signature);
   }
 }

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 import { SharedModule } from 'src/shared/shared.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   controllers: [OrdersController],
   providers: [OrdersService],
-  imports: [SharedModule],
+  imports: [SharedModule, ConfigModule],
 })
 export class OrdersModule {}

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -1,0 +1,417 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrdersService } from './orders.service';
+import { PrismaService } from 'src/shared/prisma.service';
+import { BlockchainService } from 'src/shared/blockhain.service';
+import { StringUtilService } from 'src/shared/string-util.service';
+import { ConfigService } from '@nestjs/config';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { baseSepolia } from 'viem/chains';
+import { UnsignedTypedDataDto } from './dto/unsigned-typed-data.dto';
+import { OrderStatus } from '@prisma/client';
+
+describe('OrdersService', () => {
+  let service: OrdersService;
+  let prismaService: PrismaService;
+  let blockchainService: BlockchainService;
+  let stringUtilService: StringUtilService;
+  let configService: ConfigService;
+
+  const mockPrismaService = {
+    orders: {
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  const mockBlockchainService = {
+    getDecimalsERC20: jest.fn(),
+    getPublicClient: jest.fn(),
+  };
+
+  const mockStringUtilService = {
+    generateSalt: jest.fn(),
+  };
+
+  const mockConfigService = {
+    getOrThrow: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+        {
+          provide: BlockchainService,
+          useValue: mockBlockchainService,
+        },
+        {
+          provide: StringUtilService,
+          useValue: mockStringUtilService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<OrdersService>(OrdersService);
+    prismaService = module.get<PrismaService>(PrismaService);
+    blockchainService = module.get<BlockchainService>(BlockchainService);
+    stringUtilService = module.get<StringUtilService>(StringUtilService);
+    configService = module.get<ConfigService>(ConfigService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    const mockCreateOrderDto: CreateOrderDto = {
+      maker: '0x1234567890123456789012345678901234567890',
+      makerToken: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      makerAmount: '1000000000000000000',
+      takerToken: '0x9876543210987654321098765432109876543210',
+      takerAmount: '2000000000000000000',
+    };
+
+    const mockSalt = 'mock-salt-123456';
+    const mockMakerTokenDecimals = 18;
+    const mockTakerTokenDecimals = 6;
+    const mockContractAddress = '0xcontract1234567890123456789012345678901234';
+
+    const mockCreatedOrder = {
+      id: 1,
+      maker: mockCreateOrderDto.maker,
+      makerToken: mockCreateOrderDto.makerToken,
+      makerAmount: BigInt(mockCreateOrderDto.makerAmount),
+      takerToken: mockCreateOrderDto.takerToken,
+      takerAmount: BigInt(mockCreateOrderDto.takerAmount),
+      salt: mockSalt,
+      makerTokenDecimals: mockMakerTokenDecimals,
+      takerTokenDecimals: mockTakerTokenDecimals,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    beforeEach(() => {
+      mockBlockchainService.getDecimalsERC20.mockResolvedValueOnce(
+        mockMakerTokenDecimals,
+      );
+      mockBlockchainService.getDecimalsERC20.mockResolvedValueOnce(
+        mockTakerTokenDecimals,
+      );
+      mockStringUtilService.generateSalt.mockReturnValue(mockSalt);
+      mockConfigService.getOrThrow.mockReturnValue(mockContractAddress);
+      mockPrismaService.orders.create.mockResolvedValue(mockCreatedOrder);
+    });
+
+    it('should create an order and return unsigned typed data', async () => {
+      const result = await service.create(mockCreateOrderDto);
+
+      expect(result).toEqual({
+        account: mockCreateOrderDto.maker,
+        domain: {
+          name: 'Owna',
+          version: '1',
+          chainId: baseSepolia.id,
+          verifyingContract: mockContractAddress,
+        },
+        types: {
+          Order: [
+            { name: 'maker', type: 'address' },
+            { name: 'makerToken', type: 'address' },
+            { name: 'makerAmount', type: 'uint256' },
+            { name: 'takerToken', type: 'address' },
+            { name: 'takerAmount', type: 'uint256' },
+            { name: 'salt', type: 'string' },
+          ],
+        },
+        primaryType: 'Order',
+        message: {
+          maker: mockCreatedOrder.maker,
+          makerToken: mockCreatedOrder.makerToken,
+          makerAmount: mockCreatedOrder.makerAmount.toString(),
+          takerToken: mockCreatedOrder.takerToken,
+          takerAmount: mockCreatedOrder.takerAmount.toString(),
+          salt: mockCreatedOrder.salt,
+        },
+      });
+    });
+
+    it('should fetch decimals for both maker and taker tokens', async () => {
+      await service.create(mockCreateOrderDto);
+
+      expect(blockchainService.getDecimalsERC20).toHaveBeenCalledTimes(2);
+      expect(blockchainService.getDecimalsERC20).toHaveBeenCalledWith(
+        mockCreateOrderDto.makerToken,
+      );
+      expect(blockchainService.getDecimalsERC20).toHaveBeenCalledWith(
+        mockCreateOrderDto.takerToken,
+      );
+    });
+
+    it('should generate a salt for the order', async () => {
+      await service.create(mockCreateOrderDto);
+
+      expect(stringUtilService.generateSalt).toHaveBeenCalledTimes(1);
+    });
+
+    it('should save the order to the database with correct data', async () => {
+      await service.create(mockCreateOrderDto);
+
+      expect(prismaService.orders.create).toHaveBeenCalledWith({
+        data: {
+          ...mockCreateOrderDto,
+          makerTokenDecimals: mockMakerTokenDecimals,
+          takerTokenDecimals: mockTakerTokenDecimals,
+          salt: mockSalt,
+        },
+      });
+    });
+
+    it('should retrieve the contract address from config', async () => {
+      await service.create(mockCreateOrderDto);
+
+      expect(configService.getOrThrow).toHaveBeenCalledWith(
+        'SECONDARY_MARKET_CONTRACT_ADDRESS',
+      );
+    });
+
+    it('should handle errors when fetching token decimals fails', async () => {
+      const error = new Error('Failed to fetch decimals');
+      mockBlockchainService.getDecimalsERC20.mockReset();
+      mockBlockchainService.getDecimalsERC20.mockRejectedValue(error);
+
+      await expect(service.create(mockCreateOrderDto)).rejects.toThrow(
+        'Failed to fetch decimals',
+      );
+    });
+
+    it('should handle errors when database creation fails', async () => {
+      const error = new Error('Database error');
+      mockPrismaService.orders.create.mockRejectedValue(error);
+
+      await expect(service.create(mockCreateOrderDto)).rejects.toThrow(
+        'Database error',
+      );
+    });
+  });
+
+  describe('verifySignedOrder', () => {
+    const mockUnsignedTypedData: UnsignedTypedDataDto = {
+      account: '0x1234567890123456789012345678901234567890',
+      domain: {
+        name: 'Owna',
+        version: '1',
+        chainId: baseSepolia.id,
+        verifyingContract: '0xcontract1234567890123456789012345678901234',
+      },
+      types: {
+        Order: [
+          { name: 'maker', type: 'address' },
+          { name: 'makerToken', type: 'address' },
+          { name: 'makerAmount', type: 'uint256' },
+          { name: 'takerToken', type: 'address' },
+          { name: 'takerAmount', type: 'uint256' },
+          { name: 'salt', type: 'string' },
+        ] as const,
+      },
+      primaryType: 'Order' as const,
+      message: {
+        maker: '0x1234567890123456789012345678901234567890',
+        makerToken: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        makerAmount: '1000000000000000000',
+        takerToken: '0x9876543210987654321098765432109876543210',
+        takerAmount: '2000000000000000000',
+        salt: 'test-salt-123456',
+      },
+    };
+
+    const mockSignature =
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12';
+
+    const mockUpdatedOrder = {
+      id: 1,
+      status: OrderStatus.ACTIVE,
+      maker: mockUnsignedTypedData.message.maker,
+      makerToken: mockUnsignedTypedData.message.makerToken,
+      makerAmount: BigInt(mockUnsignedTypedData.message.makerAmount),
+      takerToken: mockUnsignedTypedData.message.takerToken,
+      takerAmount: BigInt(mockUnsignedTypedData.message.takerAmount),
+      salt: mockUnsignedTypedData.message.salt,
+      signature: mockSignature,
+      makerTokenDecimals: 18,
+      takerTokenDecimals: 6,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('should verify signature successfully and return true', async () => {
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockResolvedValue(true),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+      mockPrismaService.orders.update.mockResolvedValue(mockUpdatedOrder);
+
+      const result = await service.verifySignedOrder(
+        mockUnsignedTypedData,
+        mockSignature,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should verify signature and return false when signature is invalid', async () => {
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockResolvedValue(false),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+      mockPrismaService.orders.update.mockResolvedValue(mockUpdatedOrder);
+
+      const result = await service.verifySignedOrder(
+        mockUnsignedTypedData,
+        mockSignature,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should call verifyTypedData with correct parameters', async () => {
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockResolvedValue(true),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+      mockPrismaService.orders.update.mockResolvedValue(mockUpdatedOrder);
+
+      await service.verifySignedOrder(mockUnsignedTypedData, mockSignature);
+
+      expect(mockPublicClient.verifyTypedData).toHaveBeenCalledTimes(1);
+      expect(mockPublicClient.verifyTypedData).toHaveBeenCalledWith({
+        address: mockUnsignedTypedData.account,
+        domain: mockUnsignedTypedData.domain,
+        types: mockUnsignedTypedData.types,
+        primaryType: mockUnsignedTypedData.primaryType,
+        message: mockUnsignedTypedData.message,
+        signature: mockSignature,
+      });
+    });
+
+    it('should update order status to ACTIVE and save signature', async () => {
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockResolvedValue(true),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+      mockPrismaService.orders.update.mockResolvedValue(mockUpdatedOrder);
+
+      await service.verifySignedOrder(mockUnsignedTypedData, mockSignature);
+
+      expect(mockPrismaService.orders.update).toHaveBeenCalledTimes(1);
+      expect(mockPrismaService.orders.update).toHaveBeenCalledWith({
+        where: {
+          salt: mockUnsignedTypedData.message.salt,
+        },
+        data: {
+          status: OrderStatus.ACTIVE,
+          signature: mockSignature,
+        },
+      });
+    });
+
+    it('should call getPublicClient from blockchain service', async () => {
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockResolvedValue(true),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+      mockPrismaService.orders.update.mockResolvedValue(mockUpdatedOrder);
+
+      await service.verifySignedOrder(mockUnsignedTypedData, mockSignature);
+
+      expect(mockBlockchainService.getPublicClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle errors when blockchain verification fails', async () => {
+      const error = new Error('Blockchain verification failed');
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockRejectedValue(error),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+
+      await expect(
+        service.verifySignedOrder(mockUnsignedTypedData, mockSignature),
+      ).rejects.toThrow('Blockchain verification failed');
+    });
+
+    it('should handle errors when database update fails', async () => {
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockResolvedValue(true),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+
+      const error = new Error('Database update failed');
+      mockPrismaService.orders.update.mockRejectedValue(error);
+
+      await expect(
+        service.verifySignedOrder(mockUnsignedTypedData, mockSignature),
+      ).rejects.toThrow('Database update failed');
+    });
+
+    it('should handle case when order with salt does not exist', async () => {
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockResolvedValue(true),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+
+      const error = new Error('Record not found');
+      mockPrismaService.orders.update.mockRejectedValue(error);
+
+      await expect(
+        service.verifySignedOrder(mockUnsignedTypedData, mockSignature),
+      ).rejects.toThrow('Record not found');
+    });
+
+    it('should update order even when signature is invalid', async () => {
+      const mockPublicClient = {
+        verifyTypedData: jest.fn().mockResolvedValue(false),
+      };
+
+      mockBlockchainService.getPublicClient.mockReturnValue(mockPublicClient);
+      mockPrismaService.orders.update.mockResolvedValue({
+        ...mockUpdatedOrder,
+        status: OrderStatus.ACTIVE,
+      });
+
+      const result = await service.verifySignedOrder(
+        mockUnsignedTypedData,
+        mockSignature,
+      );
+
+      expect(result).toBe(false);
+      expect(mockPrismaService.orders.update).toHaveBeenCalledWith({
+        where: {
+          salt: mockUnsignedTypedData.message.salt,
+        },
+        data: {
+          status: OrderStatus.ACTIVE,
+          signature: mockSignature,
+        },
+      });
+    });
+  });
+});

--- a/src/shared/blockhain.service.ts
+++ b/src/shared/blockhain.service.ts
@@ -6,6 +6,10 @@ import { baseSepolia } from 'viem/chains';
 export class BlockchainService {
   client = createPublicClient({ chain: baseSepolia, transport: http() });
 
+  getPublicClient() {
+    return this.client;
+  }
+
   async getDecimalsERC20(address: Address): Promise<number> {
     const decimals = await this.client.readContract({
       address: address,


### PR DESCRIPTION
This pull request refactors the orders module to support typed data signing and verification for blockchain-based orders. It introduces a new DTO for unsigned typed data, updates the order creation flow to return typed data for signing, and adds an endpoint for verifying signed orders. Several unused DTOs and endpoints have been removed to simplify the codebase.

### Typed Data Signing and Verification

* Added `UnsignedTypedDataDto` to represent typed data for blockchain order signing, including domain, types, primary type, and message fields. (`src/orders/dto/unsigned-typed-data.dto.ts`)
* Updated the order creation flow in `OrdersService` to return an `UnsignedTypedDataDto` for signing, using contract address from config and chain details. (`src/orders/orders.service.ts`) [[1]](diffhunk://#diff-f5174d3ea5bb2bc57acfe2b61634852a535c9f5d4841cc4390b637054950951eL3-R22) [[2]](diffhunk://#diff-f5174d3ea5bb2bc57acfe2b61634852a535c9f5d4841cc4390b637054950951eR41-R96)
* Added a new `verifySignedOrder` endpoint to `OrdersController` for verifying signed orders and updating their status in the database. (`src/orders/orders.controller.ts`, `src/orders/orders.service.ts`) [[1]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L1-R22) [[2]](diffhunk://#diff-f5174d3ea5bb2bc57acfe2b61634852a535c9f5d4841cc4390b637054950951eR41-R96)

### API and DTO Cleanup

* Removed unused DTOs (`SaltedOrderDto`, `UpdateOrderDto`) and related endpoints (`findAll`, `findOne`, `update`, `remove`) from the orders controller and service for a cleaner API surface. (`src/orders/dto/salted-order.dto.ts`, `src/orders/dto/update-order.dto.ts`, `src/orders/orders.controller.ts`, `src/orders/orders.service.ts`) [[1]](diffhunk://#diff-1b2c1a1982158d38be203561072d9183a63f159ced87d71aeb6cc5bccecca41fL1-L5) [[2]](diffhunk://#diff-bef2463f115883c915cb675e7bd883be7a84013d405cbdd9709506112eba16c4L1-L4) [[3]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L1-R22) [[4]](diffhunk://#diff-f5174d3ea5bb2bc57acfe2b61634852a535c9f5d4841cc4390b637054950951eL3-R22)

### Configuration and Testing

* Added `SECONDARY_MARKET_CONTRACT_ADDRESS` to `.env.example` for contract address configuration. (`.env.example`)
* Registered `ConfigModule` in `OrdersModule` to support environment-based configuration. (`src/orders/orders.module.ts`)
* Added `moduleNameMapper` to Jest configuration in `package.json` for improved import paths. (`package.json`)

### Blockchain Service Utility

* Added a `getPublicClient` method to `BlockchainService` to expose the public client for typed data verification. (`src/shared/blockhain.service.ts`)