### PR TITLE
feat: add execute order functionality

### DIFF
--- a/src/orders/dto/signed-typed-data-response.dto.ts
+++ b/src/orders/dto/signed-typed-data-response.dto.ts
@@ -1,0 +1,6 @@
+import { UnsignedTypedDataDto } from './unsigned-typed-data.dto';
+
+export class SignedTypedDataResponseDto {
+  typedData: UnsignedTypedDataDto;
+  signature: string;
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Post, Body, Get, Query } from '@nestjs/common';
+import { Controller, Post, Body, Get, Query, Param } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { UnsignedTypedDataDto } from './dto/unsigned-typed-data.dto';
 import { PaginationQueryDto } from './dto/pagination-query.dto';
 import { PaginatedOrdersResponseDto } from './dto/paginated-orders-response.dto';
+import { SignedTypedDataResponseDto } from './dto/signed-typed-data-response.dto';
 
 @Controller('orders')
 export class OrdersController {
@@ -29,5 +30,12 @@ export class OrdersController {
     @Query() paginationQuery: PaginationQueryDto,
   ): Promise<PaginatedOrdersResponseDto> {
     return await this.ordersService.getOrders(paginationQuery);
+  }
+
+  @Get(':orderId/execute')
+  async executeOrder(
+    @Param('orderId') orderId: string,
+  ): Promise<SignedTypedDataResponseDto> {
+    return await this.ordersService.executeOrder(+orderId);
   }
 }


### PR DESCRIPTION
This pull request introduces a new feature to execute orders and return their signed typed data, along with comprehensive error handling and supporting DTOs. The changes include a new endpoint in the `OrdersController`, the corresponding service logic in `OrdersService`, a new DTO for the signed typed data response, and extensive unit tests for the new functionality.

**New order execution functionality:**

* Added a new `GET /orders/:orderId/execute` endpoint to `OrdersController` that allows clients to execute an order and retrieve its signed typed data.
* Implemented the `executeOrder` method in `OrdersService` to fetch an order, validate its status and signature, and return a `SignedTypedDataResponseDto`. Throws appropriate exceptions for missing, inactive, or unsigned orders.

**Supporting code and tests:**

* Created the new `SignedTypedDataResponseDto` class to structure the response for executed orders.
* Added comprehensive unit tests for the `executeOrder` method, covering successful execution, error cases, and correct data retrieval.

**Imports and setup:**

* Updated imports in controllers, services, and tests to include the new DTO and exception classes. [[1]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L1-R7) [[2]](diffhunk://#diff-f5174d3ea5bb2bc57acfe2b61634852a535c9f5d4841cc4390b637054950951eL1-R5) [[3]](diffhunk://#diff-f5174d3ea5bb2bc57acfe2b61634852a535c9f5d4841cc4390b637054950951eR17) [[4]](diffhunk://#diff-6574d03f08d931cd2a33750347c50513dbdd6dce2303c692490bc9d760355e52R11-R14) [[5]](diffhunk://#diff-6574d03f08d931cd2a33750347c50513dbdd6dce2303c692490bc9d760355e52R27)