### PR TITLE
docs: add api docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "6.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)
+      '@nestjs/swagger':
+        specifier: ^11.2.0
+        version: 11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
       '@prisma/client':
         specifier: 6.16.3
         version: 6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3)
@@ -648,6 +651,9 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@microsoft/tsdoc@0.15.1':
+    resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -724,6 +730,23 @@ packages:
     resolution: {integrity: sha512-t8dNYYMwEeEsrlwc2jbkfwCfXczq4AeNEgx1KVQuJ6wYibXk0ZbXbPdfp8scnEAaQv1grpncNV5gWgzi7ZwbvQ==}
     peerDependencies:
       typescript: '>=4.8.2'
+
+  '@nestjs/swagger@11.2.0':
+    resolution: {integrity: sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   '@nestjs/testing@11.1.6':
     resolution: {integrity: sha512-srYzzDNxGvVCe1j0SpTS9/ix75PKt6Sn6iMaH1rpJ6nj2g8vwNrhK0CoJJXvpCYgrnI+2WES2pprYnq8rAMYHA==}
@@ -807,6 +830,9 @@ packages:
 
   '@prisma/get-platform@6.16.3':
     resolution: {integrity: sha512-X1LxiFXinJ4iQehrodGp0f66Dv6cDL0GbRlcCoLtSu6f4Wi+hgo7eND/afIs5029GQLgNWKZ46vn8hjyXTsHLA==}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
@@ -2929,6 +2955,9 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  swagger-ui-dist@5.21.0:
+    resolution: {integrity: sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==}
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -3942,6 +3971,8 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@microsoft/tsdoc@0.15.1': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -4055,6 +4086,21 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@nestjs/swagger@11.2.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      path-to-regexp: 8.2.0
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.21.0
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
+
   '@nestjs/testing@11.1.6(@nestjs/common@11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@nestjs/platform-express@11.1.6)':
     dependencies:
       '@nestjs/common': 11.1.6(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -4130,6 +4176,8 @@ snapshots:
   '@prisma/get-platform@6.16.3':
     dependencies:
       '@prisma/debug': 6.16.3
+
+  '@scarf/scarf@1.4.0': {}
 
   '@scure/base@1.2.6': {}
 
@@ -6483,6 +6531,10 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  swagger-ui-dist@5.21.0:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   symbol-observable@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 onlyBuiltDependencies:
   - '@nestjs/core'
   - '@prisma/engines'
+  - '@scarf/scarf'
   - prisma

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,11 +1,15 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
+@ApiTags('health')
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Health check endpoint' })
+  @ApiResponse({ status: 200, description: 'Service is running', type: String })
   getHello(): string {
     return this.appService.getHello();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,34 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  
+  // Enable CORS
+  app.enableCors();
+  
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
       whitelist: true,
     }),
   );
+
+  // Swagger Configuration
+  const config = new DocumentBuilder()
+    .setTitle('Owna Finance - Secondary Market API')
+    .setDescription('API documentation for Owna Finance Secondary Market backend service')
+    .setVersion('1.0')
+    .addTag('orders', 'Order management endpoints')
+    .build();
+  
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api-docs', app, document);
+
   await app.listen(process.env.PORT ?? 3000);
+  console.log(`Application is running on: http://localhost:${process.env.PORT ?? 3000}`);
+  console.log(`Swagger API docs available at: http://localhost:${process.env.PORT ?? 3000}/api-docs`);
 }
 bootstrap();

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -1,6 +1,12 @@
 import { IsString, IsNotEmpty, Matches, IsNumberString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateOrderDto {
+  @ApiProperty({
+    description: 'The Ethereum address of the order maker',
+    example: '0x1234567890123456789012345678901234567890',
+    pattern: '^0x[a-fA-F0-9]{40}$'
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
@@ -8,6 +14,11 @@ export class CreateOrderDto {
   })
   maker: string;
 
+  @ApiProperty({
+    description: 'The token address that the maker is offering',
+    example: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+    pattern: '^0x[a-fA-F0-9]{40}$'
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
@@ -15,10 +26,20 @@ export class CreateOrderDto {
   })
   makerToken: string;
 
+  @ApiProperty({
+    description: 'The amount of maker tokens being offered',
+    example: '1000000000000000000',
+    type: String
+  })
   @IsNumberString()
   @IsNotEmpty()
   makerAmount: string;
 
+  @ApiProperty({
+    description: 'The token address that the maker wants in exchange',
+    example: '0xfedcbafedcbafedcbafedcbafedcbafedcbafed',
+    pattern: '^0x[a-fA-F0-9]{40}$'
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
@@ -26,6 +47,11 @@ export class CreateOrderDto {
   })
   takerToken: string;
 
+  @ApiProperty({
+    description: 'The amount of taker tokens desired',
+    example: '2000000000000000000',
+    type: String
+  })
   @IsNumberString()
   @IsNotEmpty()
   takerAmount: string;

--- a/src/orders/dto/paginated-orders-response.dto.ts
+++ b/src/orders/dto/paginated-orders-response.dto.ts
@@ -1,28 +1,60 @@
 import { IsArray, IsInt, IsPositive, Min, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class PaginationMetaDto {
+  @ApiProperty({
+    description: 'Total number of orders in the database',
+    example: 100,
+    minimum: 0
+  })
   @IsInt()
   @Min(0)
   total: number;
 
+  @ApiProperty({
+    description: 'Current page number',
+    example: 1,
+    minimum: 1
+  })
   @IsInt()
   @IsPositive()
   page: number;
 
+  @ApiProperty({
+    description: 'Number of items per page',
+    example: 10,
+    minimum: 1
+  })
   @IsInt()
   @IsPositive()
   limit: number;
 
+  @ApiProperty({
+    description: 'Total number of pages',
+    example: 10,
+    minimum: 0
+  })
   @IsInt()
   @Min(0)
   totalPages: number;
 }
 
 export class PaginatedOrdersResponseDto {
+  @ApiProperty({
+    description: 'Array of order objects',
+    type: 'array',
+    items: {
+      type: 'object'
+    }
+  })
   @IsArray()
   data: any[];
 
+  @ApiProperty({
+    description: 'Pagination metadata',
+    type: PaginationMetaDto
+  })
   @ValidateNested()
   @Type(() => PaginationMetaDto)
   meta: PaginationMetaDto;

--- a/src/orders/dto/pagination-query.dto.ts
+++ b/src/orders/dto/pagination-query.dto.ts
@@ -1,13 +1,27 @@
 import { IsOptional, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class PaginationQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number for pagination',
+    default: 1,
+    minimum: 1,
+    example: 1
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    default: 10,
+    minimum: 1,
+    maximum: 100,
+    example: 10
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/src/orders/dto/signed-typed-data-response.dto.ts
+++ b/src/orders/dto/signed-typed-data-response.dto.ts
@@ -1,12 +1,22 @@
 import { UnsignedTypedDataDto } from './unsigned-typed-data.dto';
 import { IsString, IsNotEmpty, Matches, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class SignedTypedDataResponseDto {
+  @ApiProperty({
+    description: 'The unsigned typed data that was signed',
+    type: UnsignedTypedDataDto
+  })
   @ValidateNested()
   @Type(() => UnsignedTypedDataDto)
   typedData: UnsignedTypedDataDto;
 
+  @ApiProperty({
+    description: 'The signature of the typed data',
+    example: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12',
+    pattern: '^0x[a-fA-F0-9]{130}$'
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^0x[a-fA-F0-9]{130}$/, {

--- a/src/orders/dto/unsigned-typed-data.dto.ts
+++ b/src/orders/dto/unsigned-typed-data.dto.ts
@@ -7,8 +7,14 @@ import {
   IsObject,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class OrderMessageDto {
+  @ApiProperty({
+    description: 'The Ethereum address of the order maker',
+    example: '0x1234567890123456789012345678901234567890',
+    pattern: '^0x[a-fA-F0-9]{40}$'
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
@@ -16,6 +22,11 @@ export class OrderMessageDto {
   })
   maker: string;
 
+  @ApiProperty({
+    description: 'The token address that the maker is offering',
+    example: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+    pattern: '^0x[a-fA-F0-9]{40}$'
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
@@ -23,10 +34,20 @@ export class OrderMessageDto {
   })
   makerToken: string;
 
+  @ApiProperty({
+    description: 'The amount of maker tokens being offered',
+    example: '1000000000000000000',
+    type: String
+  })
   @IsString()
   @IsNotEmpty()
   makerAmount: string;
 
+  @ApiProperty({
+    description: 'The token address that the maker wants in exchange',
+    example: '0xfedcbafedcbafedcbafedcbafedcbafedcbafed',
+    pattern: '^0x[a-fA-F0-9]{40}$'
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
@@ -34,10 +55,20 @@ export class OrderMessageDto {
   })
   takerToken: string;
 
+  @ApiProperty({
+    description: 'The amount of taker tokens desired',
+    example: '2000000000000000000',
+    type: String
+  })
   @IsString()
   @IsNotEmpty()
   takerAmount: string;
 
+  @ApiProperty({
+    description: 'Random salt value for uniqueness',
+    example: '123456789',
+    type: String
+  })
   @IsString()
   @IsNotEmpty()
   salt: string;
@@ -46,6 +77,11 @@ export class OrderMessageDto {
 }
 
 export class UnsignedTypedDataDto {
+  @ApiProperty({
+    description: 'The Ethereum account address',
+    example: '0x1234567890123456789012345678901234567890',
+    pattern: '^0x[a-fA-F0-9]{40}$'
+  })
   @IsString()
   @IsNotEmpty()
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
@@ -53,10 +89,32 @@ export class UnsignedTypedDataDto {
   })
   account: Address;
 
+  @ApiProperty({
+    description: 'EIP-712 domain separator',
+    example: {
+      name: 'OwnaFinance',
+      version: '1',
+      chainId: 1,
+      verifyingContract: '0x1234567890123456789012345678901234567890'
+    }
+  })
   @IsObject()
   @IsNotEmpty()
   domain: TypedDataDomain;
 
+  @ApiProperty({
+    description: 'EIP-712 types definition',
+    example: {
+      Order: [
+        { name: 'maker', type: 'address' },
+        { name: 'makerToken', type: 'address' },
+        { name: 'makerAmount', type: 'uint256' },
+        { name: 'takerToken', type: 'address' },
+        { name: 'takerAmount', type: 'uint256' },
+        { name: 'salt', type: 'string' }
+      ]
+    }
+  })
   @IsObject()
   @IsNotEmpty()
   types: {
@@ -70,10 +128,19 @@ export class UnsignedTypedDataDto {
     ];
   };
 
+  @ApiProperty({
+    description: 'Primary type for EIP-712',
+    example: 'Order',
+    enum: ['Order']
+  })
   @IsString()
   @IsNotEmpty()
   primaryType: 'Order';
 
+  @ApiProperty({
+    description: 'The order message to be signed',
+    type: OrderMessageDto
+  })
   @ValidateNested()
   @Type(() => OrderMessageDto)
   message: OrderMessageDto;

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -5,12 +5,32 @@ import { UnsignedTypedDataDto } from './dto/unsigned-typed-data.dto';
 import { PaginationQueryDto } from './dto/pagination-query.dto';
 import { PaginatedOrdersResponseDto } from './dto/paginated-orders-response.dto';
 import { SignedTypedDataResponseDto } from './dto/signed-typed-data-response.dto';
+import { 
+  ApiTags, 
+  ApiOperation, 
+  ApiResponse, 
+  ApiBody,
+  ApiParam,
+  ApiQuery
+} from '@nestjs/swagger';
 
+@ApiTags('orders')
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
   @Post('')
+  @ApiOperation({ 
+    summary: 'Create a new order',
+    description: 'Creates a new order and returns unsigned typed data for signing'
+  })
+  @ApiBody({ type: CreateOrderDto })
+  @ApiResponse({ 
+    status: 201, 
+    description: 'Order created successfully. Returns unsigned typed data to be signed by the maker.',
+    type: UnsignedTypedDataDto 
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
   async create(
     @Body() createOrderDto: CreateOrderDto,
   ): Promise<UnsignedTypedDataDto> {
@@ -18,6 +38,28 @@ export class OrdersController {
   }
 
   @Post('verify')
+  @ApiOperation({ 
+    summary: 'Verify a signed order',
+    description: 'Verifies the signature of a signed order'
+  })
+  @ApiBody({ 
+    schema: {
+      type: 'object',
+      properties: {
+        order: { 
+          type: 'object',
+          description: 'The unsigned typed data'
+        },
+        signature: { 
+          type: 'string',
+          description: 'The signature to verify',
+          example: '0x...'
+        }
+      }
+    }
+  })
+  @ApiResponse({ status: 200, description: 'Order signature verified successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid signature or order data' })
   async verifySignedOrder(
     @Body() order: UnsignedTypedDataDto,
     @Body() signature: string,
@@ -26,6 +68,18 @@ export class OrdersController {
   }
 
   @Get()
+  @ApiOperation({ 
+    summary: 'Get paginated list of orders',
+    description: 'Retrieves a paginated list of all orders'
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page (default: 10, max: 100)' })
+  @ApiResponse({ 
+    status: 200, 
+    description: 'List of orders retrieved successfully',
+    type: PaginatedOrdersResponseDto 
+  })
+  @ApiResponse({ status: 400, description: 'Invalid pagination parameters' })
   async getOrders(
     @Query() paginationQuery: PaginationQueryDto,
   ): Promise<PaginatedOrdersResponseDto> {
@@ -33,6 +87,18 @@ export class OrdersController {
   }
 
   @Get(':orderId/execute')
+  @ApiOperation({ 
+    summary: 'Execute an order',
+    description: 'Executes an order by its ID and returns the signed typed data'
+  })
+  @ApiParam({ name: 'orderId', description: 'The ID of the order to execute', type: String })
+  @ApiResponse({ 
+    status: 200, 
+    description: 'Order executed successfully. Returns signed typed data.',
+    type: SignedTypedDataResponseDto 
+  })
+  @ApiResponse({ status: 404, description: 'Order not found' })
+  @ApiResponse({ status: 400, description: 'Invalid order ID' })
   async executeOrder(
     @Param('orderId') orderId: string,
   ): Promise<SignedTypedDataResponseDto> {


### PR DESCRIPTION
This pull request introduces comprehensive integration of Swagger (OpenAPI) documentation into the NestJS backend API. It adds the `@nestjs/swagger` package, configures Swagger UI, and annotates controllers and DTOs with rich metadata for improved API discoverability and developer experience. Additionally, it updates dependencies and workspace configuration to support these changes.

**Swagger/OpenAPI Integration and Documentation**

* Added `@nestjs/swagger` as a dependency and configured Swagger UI in `src/main.ts`, exposing API docs at `/api-docs` and enabling CORS for easier frontend integration. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23-R25) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR734-R750) [[4]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR4-R32)
* Annotated all controllers (`AppController`, `OrdersController`) and their endpoints with Swagger decorators (`@ApiTags`, `@ApiOperation`, `@ApiResponse`, `@ApiParam`, `@ApiQuery`, `@ApiBody`) to generate detailed endpoint documentation. [[1]](diffhunk://#diff-ef0ff0ca9442bda67ad0810654d636991173ecd7c1abcd6da09288b8815759ffR3-R12) [[2]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1R8-R62) [[3]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1R71-R101)
* Enhanced all DTOs (`CreateOrderDto`, `PaginatedOrdersResponseDto`, `PaginationQueryDto`, `SignedTypedDataResponseDto`, `UnsignedTypedDataDto`, `OrderMessageDto`) with `@ApiProperty` and `@ApiPropertyOptional` decorators to provide example values, descriptions, and validation patterns in the generated docs. [[1]](diffhunk://#diff-78d0007e91c696f95cea9e592db90864e4d4ae6625e052cd604bea4ec2b22046R2-R54) [[2]](diffhunk://#diff-edf5d051994b295f7373362c1ebfc19525e4efb6bc3c9e3daea82157c03e3d7cR3-R57) [[3]](diffhunk://#diff-8887d98d35d7cf85b0bfd84e190b11239a77ec93a2ff86b7884344b8ee715d2aR3-R24) [[4]](diffhunk://#diff-8f36ae65ed00a7f2b0b4bb09542fb8b905e1461a1eb4ebaf329f978076f58fe0R4-R19) [[5]](diffhunk://#diff-59335779b414c2ccb0eb752be2a9ecf449d5f59ef7e1cb18495841f4c79d61c0R10-R71) [[6]](diffhunk://#diff-59335779b414c2ccb0eb752be2a9ecf449d5f59ef7e1cb18495841f4c79d61c0R80-R117) [[7]](diffhunk://#diff-59335779b414c2ccb0eb752be2a9ecf449d5f59ef7e1cb18495841f4c79d61c0R131-R143)

**Dependency and Workspace Updates**

* Updated `pnpm-lock.yaml` to include `@nestjs/swagger`, its peer dependencies (such as `swagger-ui-dist` and `@microsoft/tsdoc`), and their snapshots. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23-R25) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR654-R656) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR734-R750) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2958-R2960) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3974-R3975) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4089-R4103) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4180-R4181) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6535-R6538)
* Added `@scarf/scarf` to `pnpm-workspace.yaml` to ensure proper dependency management.

These changes make the API self-documenting, easier to use for clients, and more maintainable for future development.